### PR TITLE
Add user document endpoint

### DIFF
--- a/search_service/__init__.py
+++ b/search_service/__init__.py
@@ -10,7 +10,7 @@ from typing import Dict, Any    # noqa: F401
 
 from search_service.api.table import SearchTableAPI, SearchTableFieldAPI
 from search_service.api.user import SearchUserAPI
-from search_service.api.document import DocumentTableAPI
+from search_service.api.document import DocumentTableAPI, DocumentUserAPI
 from search_service.api.healthcheck import healthcheck
 
 # For customized flask use below arguments to override.
@@ -74,7 +74,9 @@ def create_app(*, config_module_class: str) -> Flask:
     # User Search API
     api.add_resource(SearchUserAPI, '/search_user')
 
+    # DocumentAPI
     api.add_resource(DocumentTableAPI, '/document_table', '/document_table/<document_id>')
+    api.add_resource(DocumentUserAPI, '/document_user', '/document_user/<document_id>')
 
     app.register_blueprint(api_bp)
 

--- a/search_service/api/document.py
+++ b/search_service/api/document.py
@@ -5,19 +5,21 @@ from typing import Tuple, Any
 
 from flask_restful import Resource, reqparse
 from search_service.proxy import get_proxy_client
+from search_service.proxy.base import BaseProxy
 from search_service.models.table import TableSchema
+from search_service.models.user import UserSchema
 from search_service.api.table import TABLE_INDEX
+from search_service.api.user import USER_INDEX
 
 LOGGER = logging.getLogger(__name__)
 
 
-class DocumentTableAPI(Resource):
-
-    def __init__(self) -> None:
-        self.proxy = get_proxy_client()
+class BaseDocumentAPI(Resource):
+    def __init__(self, schema: Any, proxy: BaseProxy) -> None:
+        self.schema = schema
+        self.proxy = proxy
         self.parser = reqparse.RequestParser(bundle_errors=True)
-        self.parser.add_argument('index', required=False, default=TABLE_INDEX, type=str)
-        super(DocumentTableAPI, self).__init__()
+        super(BaseDocumentAPI, self).__init__()
 
     def post(self) -> Tuple[Any, int]:
         """
@@ -31,7 +33,7 @@ class DocumentTableAPI(Resource):
         args = self.parser.parse_args()
 
         try:
-            data = TableSchema(many=True, unknown='EXCLUDE').loads(args.get('data'))
+            data = self.schema(many=True, unknown='EXCLUDE').loads(args.get('data'))
             results = self.proxy.create_document(data=data, index=args.get('index'))
             return results, HTTPStatus.OK
         except RuntimeError as e:
@@ -51,7 +53,7 @@ class DocumentTableAPI(Resource):
         args = self.parser.parse_args()
 
         try:
-            data = TableSchema(many=True, unknown='EXCLUDE').loads(args.get('data'))
+            data = self.schema(many=True, unknown='EXCLUDE').loads(args.get('data'))
             results = self.proxy.update_document(data=data, index=args.get('index'))
             return results, HTTPStatus.OK
         except RuntimeError as e:
@@ -75,3 +77,17 @@ class DocumentTableAPI(Resource):
             err_msg = 'Exception encountered while deleting document '
             LOGGER.error(err_msg + str(e))
             return {'message': err_msg}, HTTPStatus.INTERNAL_SERVER_ERROR
+
+
+class DocumentTableAPI(BaseDocumentAPI):
+
+    def __init__(self) -> None:
+        super().__init__(schema=TableSchema, proxy=get_proxy_client())
+        self.parser.add_argument('index', required=False, default=TABLE_INDEX, type=str)
+
+
+class DocumentUserAPI(BaseDocumentAPI):
+
+    def __init__(self) -> None:
+        super().__init__(schema=UserSchema, proxy=get_proxy_client())
+        self.parser.add_argument('index', required=False, default=USER_INDEX, type=str)

--- a/search_service/models/index_map.py
+++ b/search_service/models/index_map.py
@@ -68,6 +68,61 @@ DEFAULT_INDEX_MAP = textwrap.dedent("""
   }
 }""")
 
+USER_INDEX_MAP = textwrap.dedent("""
+{
+"mappings":{
+    "user":{
+      "properties": {
+        "email": {
+          "type":"text",
+          "analyzer": "simple",
+          "fields": {
+            "raw": {
+              "type": "keyword"
+            }
+          }
+        },
+        "first_name": {
+          "type":"text",
+          "analyzer": "simple",
+          "fields": {
+            "raw": {
+              "type": "keyword"
+            }
+          }
+        },
+        "last_name": {
+          "type":"text",
+          "analyzer": "simple",
+          "fields": {
+            "raw": {
+              "type": "keyword"
+            }
+          }
+        },
+        "name": {
+          "type":"text",
+          "analyzer": "simple",
+          "fields": {
+            "raw": {
+              "type": "keyword"
+            }
+          }
+        },
+        "total_read":{
+          "type": "long"
+        },
+        "total_own": {
+          "type": "long"
+        },
+        "total_follow": {
+          "type": "long"
+        }
+      }
+    }
+  }
+}""")
+
 
 class IndexMap:
     def __init__(self, map: str = DEFAULT_INDEX_MAP) -> None:

--- a/search_service/models/user.py
+++ b/search_service/models/user.py
@@ -1,4 +1,5 @@
-from typing import Set
+from marshmallow import Schema, fields, post_load
+from typing import Any, Dict, Set
 from .base import Base
 
 
@@ -55,3 +56,14 @@ class User(Base):
                                                             self.github_username,
                                                             self.is_active,
                                                             self.employee_type)
+
+
+class UserSchema(Schema):
+    name = fields.Str(allow_none=True)
+    email = fields.Str()
+    is_active = fields.Boolean(allow_none=True)
+    employee_type = fields.Str(allow_none=True)
+
+    @post_load
+    def make(self, data: Dict[str, Any], **kwargs: Any) -> User:
+        return User(**data)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import os
 
 from setuptools import setup, find_packages
 
-__version__ = '1.1.8'
+__version__ = '1.1.9'
 
 requirements_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'requirements.txt')
 with open(requirements_path) as requirements_file:

--- a/tests/unit/api/test_document.py
+++ b/tests/unit/api/test_document.py
@@ -3,7 +3,7 @@ import unittest
 from http import HTTPStatus
 from mock import patch, Mock
 
-from search_service.api.document import DocumentTableAPI
+from search_service.api.document import DocumentTableAPI, DocumentUserAPI
 from search_service import create_app
 
 
@@ -51,5 +51,45 @@ class DocumentTableAPITest(unittest.TestCase):
         mock_proxy.delete_document.assert_called_with(data=['fake id'], index='fake_index')
 
 
-if __name__ == '__main__':
-    unittest.main()
+class DocumentUserAPITest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.app = create_app(config_module_class='search_service.config.Config')
+        self.app_context = self.app.app_context()
+        self.app_context.push()
+
+    def tear_down(self):
+        self.app_context.pop()
+
+    @patch('search_service.api.document.UserSchema')
+    @patch('search_service.api.document.reqparse.RequestParser')
+    @patch('search_service.api.document.get_proxy_client')
+    def test_post(self, get_proxy, RequestParser, UserSchema) -> None:
+        mock_proxy = get_proxy.return_value = Mock()
+        RequestParser().parse_args.return_value = dict(data='{}', index='fake_index')
+        expected_value = UserSchema().loads.return_value = Mock()
+
+        response = DocumentUserAPI().post()
+        self.assertEqual(list(response)[1], HTTPStatus.OK)
+        mock_proxy.create_document.assert_called_with(data=expected_value, index='fake_index')
+
+    @patch('search_service.api.document.UserSchema')
+    @patch('search_service.api.document.reqparse.RequestParser')
+    @patch('search_service.api.document.get_proxy_client')
+    def test_put(self, get_proxy, RequestParser, UserSchema) -> None:
+        mock_proxy = get_proxy.return_value = Mock()
+        RequestParser().parse_args.return_value = dict(data='{}', index='fake_index')
+        expected_value = UserSchema().loads.return_value = Mock()
+
+        response = DocumentUserAPI().put()
+        self.assertEqual(list(response)[1], HTTPStatus.OK)
+        mock_proxy.update_document.assert_called_with(data=expected_value, index='fake_index')
+
+    @patch('search_service.api.document.reqparse.RequestParser')
+    @patch('search_service.api.document.get_proxy_client')
+    def test_delete(self, get_proxy, RequestParser) -> None:
+        mock_proxy = get_proxy.return_value = Mock()
+        RequestParser().parse_args.return_value = dict(data='[]', index='fake_index')
+
+        response = DocumentUserAPI().delete(document_id='fake id')
+        self.assertEqual(list(response)[1], HTTPStatus.OK)
+        mock_proxy.delete_document.assert_called_with(data=['fake id'], index='fake_index')


### PR DESCRIPTION
### Summary of Changes

This PR creates an endpoint for updating the user index in elasticsearch. The document endpoint previously only supported table document updates.

### Tests

I added tests for the api endpoint to match the tests I made previously for table documents

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes. 
- [x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
- [x] PR passes `make test`
- [x] I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
